### PR TITLE
feat: Implement plugin cleanup command - TPM Feature Parity Complete! 🎉

### DIFF
--- a/bin/clean
+++ b/bin/clean
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+
+# Plugin cleanup command for TPM Redux
+
+CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+LIB_DIR="$CURRENT_DIR/../lib"
+
+# Source libraries
+source "$LIB_DIR/core.sh"
+source "$LIB_DIR/git.sh"
+
+# Get list of installed plugin directories
+get_installed_plugins() {
+    local tpm_path
+    tpm_path="$(get_tpm_path)"
+
+    if [[ ! -d "$tpm_path" ]]; then
+        return 0
+    fi
+
+    # List directories in plugin path
+    find "$tpm_path" -mindepth 1 -maxdepth 1 -type d -exec basename {} \;
+}
+
+# Get list of plugins that should be removed
+# Args:
+#   $1 - config file path
+get_plugins_to_remove() {
+    local config_path="$1"
+    local installed_plugins
+    local configured_plugins
+    local configured_plugin_names=""
+
+    # Get configured plugins
+    configured_plugins="$(parse_plugins "$config_path")"
+
+    # Extract plugin names from specs
+    while IFS= read -r plugin_spec; do
+        [[ -z "$plugin_spec" ]] && continue
+        local plugin_name
+        plugin_name="$(get_plugin_name "$plugin_spec")"
+        configured_plugin_names="$configured_plugin_names$plugin_name"$'\n'
+    done <<< "$configured_plugins"
+
+    # Get installed plugins
+    installed_plugins="$(get_installed_plugins)"
+
+    # Find plugins that are installed but not configured
+    while IFS= read -r installed_plugin; do
+        [[ -z "$installed_plugin" ]] && continue
+
+        # Don't remove tpm-redux or tpm (plugin managers)
+        if [[ "$installed_plugin" == "tpm-redux" ]] || [[ "$installed_plugin" == "tpm" ]]; then
+            continue
+        fi
+
+        # Check if this plugin is in configured list
+        if ! echo "$configured_plugin_names" | grep -qx "$installed_plugin"; then
+            echo "$installed_plugin"
+        fi
+    done <<< "$installed_plugins"
+}
+
+# Format output message for a plugin removal
+# Args:
+#   $1 - plugin name
+#   $2 - status (success, error)
+format_clean_output() {
+    local plugin_name="$1"
+    local status="$2"
+
+    case "$status" in
+        success)
+            echo "✓ $plugin_name - removed"
+            ;;
+        error)
+            echo "✗ $plugin_name - removal failed"
+            ;;
+        *)
+            echo "  $plugin_name - $status"
+            ;;
+    esac
+}
+
+# Remove a single plugin
+# Args:
+#   $1 - plugin name
+# Returns:
+#   0 - success
+#   1 - error
+remove_plugin() {
+    local plugin_name="$1"
+    local tpm_path
+    local plugin_path
+
+    tpm_path="$(get_tpm_path)"
+    plugin_path="${tpm_path%/}/${plugin_name}"
+
+    if [[ ! -d "$plugin_path" ]]; then
+        return 1
+    fi
+
+    rm -rf "$plugin_path"
+    return $?
+}
+
+# Clean all unused plugins
+# Args:
+#   $1 - optional config path (defaults to detected config)
+clean_plugins() {
+    local config_path="${1:-$(get_tmux_config_path)}"
+    local plugins_to_remove
+    local removed_count=0
+    local error_count=0
+
+    # Get list of plugins to remove
+    plugins_to_remove="$(get_plugins_to_remove "$config_path")"
+
+    # Count plugins (handle empty string)
+    local total_count=0
+    if [[ -n "$plugins_to_remove" ]]; then
+        total_count="$(echo "$plugins_to_remove" | wc -l | tr -d ' ')"
+    fi
+
+    if [[ "$total_count" -eq 0 ]]; then
+        echo "No unused plugins to remove"
+        return 0
+    fi
+
+    echo "Removing $total_count unused plugin(s)..."
+    echo ""
+
+    # Remove each plugin
+    while IFS= read -r plugin_name; do
+        [[ -z "$plugin_name" ]] && continue
+
+        if remove_plugin "$plugin_name"; then
+            format_clean_output "$plugin_name" "success"
+            ((removed_count++))
+        else
+            format_clean_output "$plugin_name" "error"
+            ((error_count++))
+        fi
+    done <<< "$plugins_to_remove"
+
+    # Print summary
+    echo ""
+    echo "Cleanup complete:"
+    echo "  ✓ Removed: $removed_count"
+    if [[ $error_count -gt 0 ]]; then
+        echo "  ✗ Failed: $error_count"
+    fi
+
+    # Return success if no errors
+    [[ $error_count -eq 0 ]]
+}
+
+# Main execution (unless sourced for tests)
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    clean_plugins "$@"
+fi
+

--- a/bindings/clean_plugins
+++ b/bindings/clean_plugins
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
 
 # Keybinding wrapper for cleaning unused plugins
-# TODO: Will be implemented in feat/clean-command
 
-echo "Clean plugins functionality coming soon..."
+CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+BIN_DIR="$CURRENT_DIR/../bin"
+
+# Run the clean command
+"$BIN_DIR/clean"
 

--- a/tests/clean_test.bats
+++ b/tests/clean_test.bats
@@ -1,0 +1,164 @@
+#!/usr/bin/env bats
+
+# Tests for bin/clean - Plugin cleanup command
+
+load test_helper
+
+setup() {
+    setup_temp_dir
+    export PROJECT_ROOT=$(get_project_root)
+    export TMUX_PLUGIN_MANAGER_PATH="$TPM_TEST_DIR/plugins"
+    export TPM_TEST_MODE=1
+    mkdir -p "$TMUX_PLUGIN_MANAGER_PATH"
+
+    # Source libraries
+    source "$PROJECT_ROOT/lib/core.sh"
+    source "$PROJECT_ROOT/lib/git.sh"
+    source "$PROJECT_ROOT/bin/clean"
+}
+
+teardown() {
+    teardown_temp_dir
+}
+
+# Test: get_installed_plugins function
+
+@test "get_installed_plugins lists all plugin directories" {
+    # Create some mock plugin directories
+    mkdir -p "$TMUX_PLUGIN_MANAGER_PATH/plugin1"
+    mkdir -p "$TMUX_PLUGIN_MANAGER_PATH/plugin2"
+    mkdir -p "$TMUX_PLUGIN_MANAGER_PATH/plugin3"
+
+    run get_installed_plugins
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "plugin1" ]]
+    [[ "$output" =~ "plugin2" ]]
+    [[ "$output" =~ "plugin3" ]]
+}
+
+@test "get_installed_plugins returns empty for no plugins" {
+    run get_installed_plugins
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+# Test: get_plugins_to_remove function
+
+@test "get_plugins_to_remove identifies unused plugins" {
+    # Create config with only plugin1
+    local config="$TPM_TEST_DIR/tmux.conf"
+    echo "set -g @plugin 'user/plugin1'" > "$config"
+
+    # Create installed plugins
+    mkdir -p "$TMUX_PLUGIN_MANAGER_PATH/plugin1"
+    mkdir -p "$TMUX_PLUGIN_MANAGER_PATH/plugin2"
+    mkdir -p "$TMUX_PLUGIN_MANAGER_PATH/plugin3"
+
+    run get_plugins_to_remove "$config"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "plugin2" ]]
+    [[ "$output" =~ "plugin3" ]]
+    [[ ! "$output" =~ "plugin1" ]]
+}
+
+@test "get_plugins_to_remove returns empty when all are used" {
+    local config="$TPM_TEST_DIR/tmux.conf"
+    cat > "$config" <<'EOF'
+set -g @plugin 'user/plugin1'
+set -g @plugin 'user/plugin2'
+EOF
+
+    mkdir -p "$TMUX_PLUGIN_MANAGER_PATH/plugin1"
+    mkdir -p "$TMUX_PLUGIN_MANAGER_PATH/plugin2"
+
+    run get_plugins_to_remove "$config"
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "get_plugins_to_remove handles tpm-redux itself" {
+    local config="$TPM_TEST_DIR/tmux.conf"
+    touch "$config"
+
+    mkdir -p "$TMUX_PLUGIN_MANAGER_PATH/tpm-redux"
+    mkdir -p "$TMUX_PLUGIN_MANAGER_PATH/unused-plugin"
+
+    run get_plugins_to_remove "$config"
+    [ "$status" -eq 0 ]
+    # Should not suggest removing tpm-redux
+    [[ ! "$output" =~ "tpm-redux" ]]
+    [[ "$output" =~ "unused-plugin" ]]
+}
+
+# Test: remove_plugin function
+
+@test "remove_plugin removes plugin directory" {
+    local plugin_dir="$TMUX_PLUGIN_MANAGER_PATH/test-plugin"
+    mkdir -p "$plugin_dir"
+    echo "test" > "$plugin_dir/file.txt"
+
+    run remove_plugin "test-plugin"
+    [ "$status" -eq 0 ]
+    [ ! -d "$plugin_dir" ]
+}
+
+@test "remove_plugin handles non-existent plugin" {
+    run remove_plugin "nonexistent"
+    [ "$status" -eq 1 ]
+}
+
+# Test: clean_plugins function
+
+@test "clean_plugins removes unused plugins" {
+    local config="$TPM_TEST_DIR/tmux.conf"
+    echo "set -g @plugin 'user/plugin1'" > "$config"
+
+    mkdir -p "$TMUX_PLUGIN_MANAGER_PATH/plugin1"
+    mkdir -p "$TMUX_PLUGIN_MANAGER_PATH/plugin2"
+    mkdir -p "$TMUX_PLUGIN_MANAGER_PATH/plugin3"
+
+    run clean_plugins "$config"
+    [ "$status" -eq 0 ]
+
+    # plugin1 should still exist
+    [ -d "$TMUX_PLUGIN_MANAGER_PATH/plugin1" ]
+
+    # plugin2 and plugin3 should be removed
+    [ ! -d "$TMUX_PLUGIN_MANAGER_PATH/plugin2" ]
+    [ ! -d "$TMUX_PLUGIN_MANAGER_PATH/plugin3" ]
+}
+
+@test "clean_plugins handles no unused plugins" {
+    local config="$TPM_TEST_DIR/tmux.conf"
+    echo "set -g @plugin 'user/plugin1'" > "$config"
+
+    mkdir -p "$TMUX_PLUGIN_MANAGER_PATH/plugin1"
+
+    run clean_plugins "$config"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "No unused" || "$output" =~ "0 plugin" ]]
+}
+
+@test "clean_plugins handles empty plugin directory" {
+    local config="$TPM_TEST_DIR/tmux.conf"
+    echo "set -g @plugin 'user/plugin1'" > "$config"
+
+    run clean_plugins "$config"
+    [ "$status" -eq 0 ]
+}
+
+# Test: format_clean_output function
+
+@test "format_clean_output formats success message" {
+    run format_clean_output "test-plugin" "success"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "test-plugin" ]]
+}
+
+@test "format_clean_output formats error message" {
+    run format_clean_output "test-plugin" "error"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "test-plugin" ]]
+    [[ "$output" =~ "fail" || "$output" =~ "error" ]]
+}
+


### PR DESCRIPTION
## Summary

Implements the final plugin cleanup command (`bin/clean`) allowing users to remove unused plugins using `prefix + Alt+u`. **This completes 100% TPM feature parity!**

## Changes

### Clean Command (`bin/clean`)

**Core Functions:**
- `get_installed_plugins()` - Lists all installed plugin directories
- `get_plugins_to_remove()` - Identifies plugins not in config
- `remove_plugin()` - Removes a single plugin directory
- `format_clean_output()` - Creates user-friendly status messages
- `clean_plugins()` - Orchestrates cleanup of all unused plugins

**Features:**
- **Smart Detection**: Finds plugins installed but not in config
- **Protection**: Never removes `tpm-redux` or `tpm` (plugin managers)
- **Safe Removal**: Uses `rm -rf` to completely remove plugin directories
- **User-Friendly Output**: Clear symbols (✓ removed, ✗ error)
- **Cleanup Summary**: Shows count of removed/failed plugins
- **Error Handling**: Gracefully handles missing directories
- **Empty Check**: Handles case when no unused plugins exist

**Example Output:**
```
Removing 2 unused plugin(s)...

✓ old-plugin - removed
✓ unused-plugin - removed

Cleanup complete:
  ✓ Removed: 2
```

### Keybinding Integration

Updated `bindings/clean_plugins` to call the actual clean command:
- `prefix + Alt+u` now fully functional
- Runs in tmux context with proper output

## Testing

✅ **84/84 tests passing** (12 new + 72 previous)

```bash
./run_tests.sh
# All 84 tests pass
```

**Test Coverage:**
- List installed plugins
- Identify unused plugins
- Protect tpm-redux from removal
- Remove plugin directories
- Handle non-existent plugins
- Multiple plugin cleanup
- No unused plugins case
- Empty plugin directory
- Output formatting (all status types)

## Backwards Compatibility

✅ 100% compatible with TPM:
- Same cleanup logic
- Same keybinding (`prefix + Alt+u`)
- Same behavior for protected plugins
- Same directory removal

## TPM Feature Parity Complete! 🎉

With this PR, TPM Redux achieves **100% feature parity** with the original TPM:

| Feature | TPM | TPM Redux | Keybinding |
|---------|-----|-----------|------------|
| Install plugins | ✅ | ✅ | `prefix + I` |
| Update plugins | ✅ | ✅ | `prefix + U` |
| Clean plugins | ✅ | ✅ | `prefix + Alt+u` |
| Auto-source plugins | ✅ | ✅ | Automatic |
| Config parsing | ✅ | ✅ | All formats |
| Branch support | ✅ | ✅ | `user/repo#branch` |
| XDG paths | ✅ | ✅ | Automatic |

**What's Next:**
- Performance optimizations (parallel operations)
- Plugin search/discovery
- Lock file support
- Community testing and feedback

## Checklist

- [x] All tests passing (84/84)
- [x] Functions documented
- [x] TPM backwards compatibility maintained
- [x] No linter errors
- [x] No whitespace issues
- [x] Keybinding connected and functional
- [x] TPM feature parity achieved