### PR TITLE
fix: Add immediate feedback during plugin updates

### DIFF
--- a/bin/update
+++ b/bin/update
@@ -56,10 +56,16 @@ update_plugin_with_feedback() {
         return 2
     fi
 
+    # Show immediate feedback that update is starting
+    echo -n "  Updating $plugin_name..."
+
     # Attempt to update the plugin
     local update_output
     update_output=$(update_plugin "$plugin_spec" 2>&1)
     local update_result=$?
+
+    # Clear the "Updating..." line and show result
+    echo -ne "\r\033[K"  # Clear line
 
     if [[ $update_result -eq 0 ]]; then
         # Check if there were actually changes


### PR DESCRIPTION
## Problem

The update command felt slow and unresponsive because:
- No output shown until git pull completes for each plugin
- Terminal appears blocked with no indication of progress
- Users can't tell if the command is running or hung

## Solution

Added immediate visual feedback:
- Shows `"Updating plugin-name..."` message **immediately** before git pull starts
- Clears the message and replaces with final result once complete
- Uses ANSI escape sequences to overwrite the "Updating..." line cleanly

## Implementation

Changes in `bin/update`:
1. Added `echo -n "  Updating $plugin_name..."` before update operation
2. Added `echo -ne "\r\033[K"` after operation to clear line
3. Final status message (`✓`, `→`, or `✗`) then displays normally

## Example Output

```
Updating 2 plugin(s)...

  Updating tmux-sensible...  # Shows immediately, git pull happens
→ tmux-sensible - already up to date  # Replaces previous line

  Updating tmux-yank...  # Shows immediately, git pull happens
→ tmux-yank - already up to date  # Replaces previous line

Update complete:
  ✓ Updated: 0
  → Already up to date: 2
```

## Testing

- ✅ All 84 tests still pass
- ✅ Manually verified feedback appears immediately
- ✅ Output formatting remains clean and readable
- ✅ No regression in functionality

## Impact

- Better UX: Users see immediate feedback
- Less confusion: Clear indication command is running
- No functional changes: Same behavior, just better communication