### PR TITLE
fix: Update command exit code for not-installed plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ TPM Redux is a modern, performance-focused reimplementation of [TPM (Tmux Plugin
 
 ## Status
 
-🎉 **v1.1 - Stable** - Production ready with 100% TPM feature parity!
+🎉 **v1.1.1 - Stable** - Production ready with 100% TPM feature parity!
 
 ## Features
 
@@ -224,7 +224,12 @@ No configuration changes needed - your existing `.tmux.conf` works as-is!
 
 ## Release Notes
 
-### v1.1.0 (Current)
+### v1.1.1 (Current)
+- 🐛 Fix: Update command no longer returns error exit code for not-installed plugins
+  - Only actual update failures now result in non-zero exit code
+  - Prevents false error messages in tmux
+
+### v1.1.0
 - ✅ Commit display UI - Shows commit information for updated plugins
   - Displays commit hashes, messages, and relative times
   - Colourised output (green for updated, yellow for up-to-date, red for errors)

--- a/bin/update
+++ b/bin/update
@@ -422,8 +422,8 @@ update_all_plugins() {
         echo "  ✗ Failed: $error_count"
     fi
 
-    # Return success if no errors or not installed
-    [[ $error_count -eq 0 ]] && [[ $not_installed_count -eq 0 ]]
+    # Return success if no errors (not installed is not an error)
+    [[ $error_count -eq 0 ]]
 }
 
 # Main execution (unless sourced for tests)


### PR DESCRIPTION
## Summary

Fixes an issue where the update command would return a non-zero exit code when plugins were not installed, causing error messages in tmux.

## Changes

- Update command now only returns error exit code for actual update failures
- Not-installed plugins are treated as informational, not errors
- Prevents false error messages: `'/Users/ryan/.tmux/plugins/tpm/bindings/update_plugins' returned 1`

## Version

Bumps version to v1.1.1 (patch release)