### PR TITLE
fix: improve color detection for xterm-256color in tmux

### DIFF
--- a/bin/update
+++ b/bin/update
@@ -22,17 +22,22 @@ terminal_supports_colours() {
         # Check for common colour-capable terminals
         case "$TERM" in
             xterm*|rxvt*|screen*|tmux*|linux|ansi|*color*)
-                # If TERM indicates tmux/screen, always allow colors
-                # (tmux popups may not have TMUX env var set)
-                if [[ "$TERM" == *"tmux"* ]] || [[ "$TERM" == *"screen"* ]]; then
+                # If we're in tmux or screen (via env var), always allow colors
+                # (tmux popups may redirect stdout, so TTY check fails)
+                if [[ -n "${TMUX:-}" ]] || [[ -n "${STY:-}" ]]; then
                     return 0
                 fi
-                # Check if we're in tmux or screen via environment
-                if [[ -n "${TMUX:-}" ]] || [[ -n "${STY:-}" ]]; then
+                # If TERM explicitly indicates tmux/screen, allow colors
+                if [[ "$TERM" == *"tmux"* ]] || [[ "$TERM" == *"screen"* ]]; then
                     return 0
                 fi
                 # For other terminals, check if stdout is a TTY
                 if [[ -t 1 ]]; then
+                    return 0
+                fi
+                # If TERM contains "color" (like xterm-256color), be permissive
+                # and allow colors even if not a TTY (common in scripts/pipes)
+                if [[ "$TERM" == *"color"* ]]; then
                     return 0
                 fi
                 ;;

--- a/bindings/update_plugins
+++ b/bindings/update_plugins
@@ -7,7 +7,6 @@ BIN_DIR="$CURRENT_DIR/../bin"
 
 # Run the update command and wait for user to review results
 "$BIN_DIR/update"
-update_exit_code=$?
 
 echo ""
 echo "press ENTER to close this pane"


### PR DESCRIPTION
## Summary

Fixes color detection in tmux popups where TERM is set to `xterm-256color` but stdout is not a TTY.

## Changes

- Allow colors when TERM contains 'color' (like xterm-256color)
- This fixes color detection in tmux popups where stdout may be redirected
- Be more permissive for color-capable terminals

## Testing

Tested with TERM=xterm-256color in tmux popup environment.