### PR TITLE
feat: support commit hash pinning in plugin specifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,12 +114,23 @@ set -g @plugin 'tmux-plugins/tmux-sensible'
 # GitHub shorthand with branch
 set -g @plugin 'tmux-plugins/tmux-yank#v2.3.0'
 
+# GitHub shorthand with tag
+set -g @plugin 'tmux-plugins/tmux-yank#v2.3.0'
+
+# GitHub shorthand with commit hash (pin to specific version)
+set -g @plugin 'tmux-plugins/tmux-resurrect#abc1234'
+
 # Full git URL
 set -g @plugin 'https://github.com/tmux-plugins/tmux-sensible.git'
 
 # SSH URL
 set -g @plugin 'git@github.com:tmux-plugins/tmux-sensible.git'
 ```
+
+**Version Pinning:**
+- **Branches**: `user/repo#branch-name` - Install from a specific branch
+- **Tags**: `user/repo#v1.0.0` - Install a specific tagged version
+- **Commit Hash**: `user/repo#abc1234` - Pin to an exact commit (7+ characters)
 
 ### Example Configuration
 

--- a/tests/git_test.bats
+++ b/tests/git_test.bats
@@ -102,6 +102,184 @@ teardown() {
     [ "$branch" = "develop" ]
 }
 
+@test "clone_plugin handles branch (not commit hash) correctly" {
+    # Create a mock git repository with remote and a branch
+    local remote_repo="$TPM_TEST_DIR/remote-repo"
+    local plugin_path="$TMUX_PLUGIN_MANAGER_PATH/test-plugin"
+
+    # Set up remote repo
+    mkdir -p "$remote_repo"
+    cd "$remote_repo"
+    git init --bare >/dev/null 2>&1
+
+    # Clone the repo first to create commits and branch
+    local temp_clone="$TPM_TEST_DIR/temp-clone"
+    git clone "$remote_repo" "$temp_clone" >/dev/null 2>&1
+    cd "$temp_clone"
+    git config user.email "test@example.com"
+    git config user.name "Test User"
+    git config commit.gpgsign false
+
+    # Create initial commit on main
+    echo "v1" > file.txt
+    git add file.txt >/dev/null 2>&1
+    git commit -m "Initial commit" >/dev/null 2>&1
+    git branch -M main >/dev/null 2>&1
+    git push -u origin main >/dev/null 2>&1
+
+    # Create a develop branch
+    git checkout -b develop >/dev/null 2>&1
+    echo "v2-dev" > file.txt
+    git add file.txt >/dev/null 2>&1
+    git commit -m "Develop commit" >/dev/null 2>&1
+    git push -u origin develop >/dev/null 2>&1
+
+    # Test cloning with branch name (not commit hash)
+    local plugin_spec="file://$remote_repo"
+
+    # Clone should use -b develop (branch, not commit hash)
+    run clone_plugin "$plugin_spec" "develop"
+    [ "$status" -eq 0 ]
+
+    # Verify it cloned the develop branch
+    local cloned_name="${remote_repo##*/}"
+    local actual_path="$TMUX_PLUGIN_MANAGER_PATH/$cloned_name"
+    [ -d "$actual_path" ]
+
+    cd "$actual_path" || exit 1
+    local current_branch
+    current_branch="$(git rev-parse --abbrev-ref HEAD)"
+    [ "$current_branch" = "develop" ]
+
+    # Verify it has the develop commit content
+    [ "$(cat file.txt)" = "v2-dev" ]
+
+    # Cleanup
+    rm -rf "$temp_clone"
+}
+
+@test "clone_plugin handles commit hash specification" {
+    # Create a mock git repository with remote
+    local remote_repo="$TPM_TEST_DIR/remote-repo"
+    local plugin_path="$TMUX_PLUGIN_MANAGER_PATH/test-plugin"
+
+    # Set up remote repo
+    mkdir -p "$remote_repo"
+    cd "$remote_repo"
+    git init --bare >/dev/null 2>&1
+
+    # Clone the repo first to create commits
+    local temp_clone="$TPM_TEST_DIR/temp-clone"
+    git clone "$remote_repo" "$temp_clone" >/dev/null 2>&1
+    cd "$temp_clone"
+    git config user.email "test@example.com"
+    git config user.name "Test User"
+    git config commit.gpgsign false
+
+    # Create first commit
+    echo "v1" > file.txt
+    git add file.txt >/dev/null 2>&1
+    git commit -m "First commit" >/dev/null 2>&1
+    git branch -M main >/dev/null 2>&1
+    git push -u origin main >/dev/null 2>&1
+
+    # Create second commit
+    echo "v2" > file.txt
+    git add file.txt >/dev/null 2>&1
+    git commit -m "Second commit" >/dev/null 2>&1
+    local second_hash
+    second_hash="$(git rev-parse --short HEAD)"
+    git push origin main >/dev/null 2>&1
+
+    # Create third commit
+    echo "v3" > file.txt
+    git add file.txt >/dev/null 2>&1
+    git commit -m "Third commit" >/dev/null 2>&1
+    git push origin main >/dev/null 2>&1
+
+    # Test cloning with commit hash - use file:// URL
+    # The plugin_spec format: file://path#hash gets parsed, hash is passed as branch param
+    local plugin_spec="file://$remote_repo"
+
+    # Test that clone_plugin correctly handles commit hash as second parameter
+    run clone_plugin "$plugin_spec" "$second_hash"
+    [ "$status" -eq 0 ]
+
+    # Verify the cloned directory exists and is at the right commit
+    # get_plugin_path will extract "remote-repo" as the name from file:// URL
+    local cloned_name="${remote_repo##*/}"
+    local actual_path="$TMUX_PLUGIN_MANAGER_PATH/$cloned_name"
+    [ -d "$actual_path" ]
+
+    cd "$actual_path" || exit 1
+    local current_hash
+    current_hash="$(git rev-parse --short HEAD)"
+    [ "$current_hash" = "$second_hash" ]
+
+    # Cleanup
+    rm -rf "$temp_clone"
+}
+
+@test "clone_plugin handles tag (not commit hash) correctly" {
+    # Create a mock git repository with remote and a tag
+    local remote_repo="$TPM_TEST_DIR/remote-repo"
+    local plugin_path="$TMUX_PLUGIN_MANAGER_PATH/test-plugin"
+
+    # Set up remote repo
+    mkdir -p "$remote_repo"
+    cd "$remote_repo"
+    git init --bare >/dev/null 2>&1
+
+    # Clone the repo first to create commits and tag
+    local temp_clone="$TPM_TEST_DIR/temp-clone"
+    git clone "$remote_repo" "$temp_clone" >/dev/null 2>&1
+    cd "$temp_clone"
+    git config user.email "test@example.com"
+    git config user.name "Test User"
+    git config commit.gpgsign false
+
+    # Create initial commit
+    echo "v1" > file.txt
+    git add file.txt >/dev/null 2>&1
+    git commit -m "Initial commit" >/dev/null 2>&1
+    git branch -M main >/dev/null 2>&1
+    git push -u origin main >/dev/null 2>&1
+
+    # Create a tag
+    git tag v1.0.0 >/dev/null 2>&1
+    git push origin v1.0.0 >/dev/null 2>&1
+
+    # Create another commit after the tag
+    echo "v2" > file.txt
+    git add file.txt >/dev/null 2>&1
+    git commit -m "Second commit" >/dev/null 2>&1
+    git push origin main >/dev/null 2>&1
+
+    # Test cloning with tag name (not commit hash)
+    local plugin_spec="file://$remote_repo"
+
+    # Clone should use -b v1.0.0 (tag, not commit hash)
+    run clone_plugin "$plugin_spec" "v1.0.0"
+    [ "$status" -eq 0 ]
+
+    # Verify it cloned the tag
+    local cloned_name="${remote_repo##*/}"
+    local actual_path="$TMUX_PLUGIN_MANAGER_PATH/$cloned_name"
+    [ -d "$actual_path" ]
+
+    cd "$actual_path" || exit 1
+    # Check that we're at the tag (detached HEAD)
+    local current_ref
+    current_ref="$(git describe --tags --exact-match HEAD 2>/dev/null || echo "")"
+    [ "$current_ref" = "v1.0.0" ]
+
+    # Verify it has the v1.0.0 commit content
+    [ "$(cat file.txt)" = "v1" ]
+
+    # Cleanup
+    rm -rf "$temp_clone"
+}
+
 # Test: update_plugin function
 
 @test "update_plugin fails for non-existent plugin" {


### PR DESCRIPTION
## Summary

Adds support for pinning plugins to specific commit hashes using the format `user/repo#abc1234`.

## Changes

- Add `is_commit_hash()` helper to detect commit hashes (7+ hex characters)
- Update `clone_plugin()` to handle commit hashes by cloning then checking out the commit
- Update README with commit hash pinning documentation
- Maintains 100% backwards compatibility with branches/tags

## Backwards Compatibility
- Branch names (e.g., `#develop`) continue to use original `-b` flag behavior
- Tag names (e.g., `#v1.0.0`) continue to use original `-b` flag behavior  
- Only commit hashes (7+ hex characters) trigger new clone-then-checkout behavior
- All existing TPM configurations work unchanged

## Testing

- Added test for `clone_plugin` with commit hash specification
- Added tests to verify branches and tags still work correctly
- All existing tests continue to pass

## Usage

```bash
# Pin to a specific commit
set -g @plugin 'tmux-plugins/tmux-resurrect#abc1234'
```

Closes #TBD