### PR TITLE
feat: parse plugins from sourced tmux config files

### DIFF
--- a/lib/core.sh
+++ b/lib/core.sh
@@ -16,8 +16,79 @@ get_tmux_config_path() {
     fi
 }
 
+# Resolve a file path to its canonical absolute path
+# Falls back to the original path if resolution fails
+# Args:
+#   $1 - path to resolve
+_resolve_path() {
+    local path="$1"
+    if command -v realpath &>/dev/null; then
+        realpath "$path" 2>/dev/null || echo "$path"
+    else
+        readlink -f "$path" 2>/dev/null || echo "$path"
+    fi
+}
+
+# Global visited-files tracker for parse_plugins (reset on each top-level call)
+_TPM_PARSE_VISITED=""
+
+# Internal recursive helper for parse_plugins
+# Reads a config file, prints @plugin declarations, and follows source directives
+# Uses _TPM_PARSE_VISITED global to prevent duplicate/circular processing
+# Args:
+#   $1 - path to config file
+_parse_plugins_recursive() {
+    local config_file="$1"
+
+    [[ ! -f "$config_file" ]] && return 0
+
+    local canonical
+    canonical="$(_resolve_path "$config_file")"
+
+    # Skip if already visited (handles duplicates and circular references)
+    if [[ ":${_TPM_PARSE_VISITED}:" == *":${canonical}:"* ]]; then
+        return 0
+    fi
+
+    _TPM_PARSE_VISITED="${_TPM_PARSE_VISITED:+${_TPM_PARSE_VISITED}:}${canonical}"
+
+    local config_dir
+    config_dir="$(dirname "$config_file")"
+
+    while IFS= read -r line || [[ -n "$line" ]]; do
+        # Skip comment lines
+        [[ "$line" =~ ^[[:space:]]*# ]] && continue
+
+        # Match @plugin declarations
+        if [[ "$line" =~ ^[[:space:]]*set(-option)?[[:space:]]+-g[[:space:]]+@plugin[[:space:]] ]]; then
+            local plugin
+            plugin=$(echo "$line" | awk '{plugin=$4; gsub(/["'"'"']/, "", plugin); print plugin}')
+            [[ -n "$plugin" ]] && echo "$plugin"
+            continue
+        fi
+
+        # Match source-file or source directives
+        if [[ "$line" =~ ^[[:space:]]*(source-file|source)[[:space:]] ]]; then
+            local sourced_path
+            sourced_path=$(echo "$line" | awk '{
+                sub(/^[[:space:]]*(source-file|source)[[:space:]]+/, "")
+                gsub(/^["'"'"']|["'"'"']$/, "")
+                print $1
+            }')
+            # Expand leading tilde
+            sourced_path="${sourced_path/#\~/$HOME}"
+            # Resolve relative paths relative to the config file's directory
+            if [[ "$sourced_path" != /* ]]; then
+                sourced_path="$config_dir/$sourced_path"
+            fi
+            _parse_plugins_recursive "$sourced_path"
+        fi
+    done < "$config_file"
+}
+
 # Parse plugin declarations from tmux config file
 # Extracts all 'set -g @plugin' lines and returns plugin names
+# Also follows source-file and source directives to find plugins in sourced files
 # Args:
 #   $1 - path to tmux config file
 parse_plugins() {
@@ -27,19 +98,8 @@ parse_plugins() {
         return 0
     fi
 
-    # Use awk for efficient single-pass parsing
-    # Matches: set -g @plugin 'name' or set-option -g @plugin "name"
-    awk '
-        /^[[:space:]]*set(-option)?[[:space:]]+-g[[:space:]]+@plugin[[:space:]]/ {
-            # Extract the plugin name (4th field)
-            plugin = $4
-            # Remove quotes (single or double)
-            gsub(/["'\'']/, "", plugin)
-            if (plugin != "") {
-                print plugin
-            }
-        }
-    ' "$config_file"
+    _TPM_PARSE_VISITED=""
+    _parse_plugins_recursive "$config_file"
 }
 
 # Get the plugin name from a plugin specification

--- a/tests/core_test.bats
+++ b/tests/core_test.bats
@@ -307,3 +307,161 @@ EOF
     [ "$status" -eq 0 ]
     [ -z "$output" ]
 }
+
+# Test: parse_plugins follows source directives
+
+@test "parse_plugins follows source-file directive (absolute path)" {
+    local config="$TPM_TEST_DIR/tmux.conf"
+    local sourced="$TPM_TEST_DIR/plugins.conf"
+
+    echo "set -g @plugin 'user/plugin-a'" > "$sourced"
+    echo "source-file $sourced" > "$config"
+
+    run parse_plugins "$config"
+    [ "$status" -eq 0 ]
+    [ "$output" = "user/plugin-a" ]
+}
+
+@test "parse_plugins follows source directive (alias without -file)" {
+    local config="$TPM_TEST_DIR/tmux.conf"
+    local sourced="$TPM_TEST_DIR/plugins.conf"
+
+    echo "set -g @plugin 'user/plugin-b'" > "$sourced"
+    echo "source $sourced" > "$config"
+
+    run parse_plugins "$config"
+    [ "$status" -eq 0 ]
+    [ "$output" = "user/plugin-b" ]
+}
+
+@test "parse_plugins returns plugins from main and sourced file in order" {
+    local config="$TPM_TEST_DIR/tmux.conf"
+    local sourced="$TPM_TEST_DIR/plugins.conf"
+
+    echo "set -g @plugin 'user/sourced-plugin'" > "$sourced"
+    cat > "$config" <<EOF
+set -g @plugin 'user/main-plugin'
+source-file $sourced
+EOF
+
+    run parse_plugins "$config"
+    [ "$status" -eq 0 ]
+    [ "${lines[0]}" = "user/main-plugin" ]
+    [ "${lines[1]}" = "user/sourced-plugin" ]
+    [ "${#lines[@]}" -eq 2 ]
+}
+
+@test "parse_plugins follows nested sourcing (A -> B -> C)" {
+    local config="$TPM_TEST_DIR/tmux.conf"
+    local b="$TPM_TEST_DIR/b.conf"
+    local c="$TPM_TEST_DIR/c.conf"
+
+    echo "set -g @plugin 'user/deep-plugin'" > "$c"
+    echo "source-file $c" > "$b"
+    echo "source-file $b" > "$config"
+
+    run parse_plugins "$config"
+    [ "$status" -eq 0 ]
+    [ "$output" = "user/deep-plugin" ]
+}
+
+@test "parse_plugins handles circular reference without infinite loop" {
+    local a="$TPM_TEST_DIR/a.conf"
+    local b="$TPM_TEST_DIR/b.conf"
+
+    cat > "$a" <<EOF
+set -g @plugin 'user/plugin-a'
+source-file $b
+EOF
+    cat > "$b" <<EOF
+set -g @plugin 'user/plugin-b'
+source-file $a
+EOF
+
+    run parse_plugins "$a"
+    [ "$status" -eq 0 ]
+    [ "${#lines[@]}" -eq 2 ]
+    [[ "$output" == *"user/plugin-a"* ]]
+    [[ "$output" == *"user/plugin-b"* ]]
+}
+
+@test "parse_plugins handles self-referencing config without infinite loop" {
+    local config="$TPM_TEST_DIR/tmux.conf"
+
+    cat > "$config" <<EOF
+set -g @plugin 'user/plugin-a'
+source-file $config
+EOF
+
+    run parse_plugins "$config"
+    [ "$status" -eq 0 ]
+    [ "${#lines[@]}" -eq 1 ]
+    [ "$output" = "user/plugin-a" ]
+}
+
+@test "parse_plugins silently skips missing sourced file" {
+    local config="$TPM_TEST_DIR/tmux.conf"
+
+    cat > "$config" <<EOF
+source-file /nonexistent/path.conf
+set -g @plugin 'user/real-plugin'
+EOF
+
+    run parse_plugins "$config"
+    [ "$status" -eq 0 ]
+    [ "$output" = "user/real-plugin" ]
+}
+
+@test "parse_plugins resolves relative path in source-file directive" {
+    mkdir -p "$TPM_TEST_DIR/subdir"
+    local config="$TPM_TEST_DIR/tmux.conf"
+    local sourced="$TPM_TEST_DIR/subdir/plugins.conf"
+
+    echo "set -g @plugin 'user/relative-plugin'" > "$sourced"
+    echo "source-file subdir/plugins.conf" > "$config"
+
+    run parse_plugins "$config"
+    [ "$status" -eq 0 ]
+    [ "$output" = "user/relative-plugin" ]
+}
+
+@test "parse_plugins expands tilde in source-file path" {
+    export HOME="$TPM_TEST_DIR/home"
+    mkdir -p "$HOME"
+    local config="$TPM_TEST_DIR/tmux.conf"
+
+    echo "set -g @plugin 'user/tilde-plugin'" > "$HOME/plugins.conf"
+    echo "source-file ~/plugins.conf" > "$config"
+
+    run parse_plugins "$config"
+    [ "$status" -eq 0 ]
+    [ "$output" = "user/tilde-plugin" ]
+}
+
+@test "parse_plugins handles double-quoted path in source-file directive" {
+    local config="$TPM_TEST_DIR/tmux.conf"
+    local sourced="$TPM_TEST_DIR/plugins.conf"
+
+    echo "set -g @plugin 'user/quoted-plugin'" > "$sourced"
+    echo "source-file \"$sourced\"" > "$config"
+
+    run parse_plugins "$config"
+    [ "$status" -eq 0 ]
+    [ "$output" = "user/quoted-plugin" ]
+}
+
+@test "parse_plugins only includes plugins once when same file sourced twice" {
+    local config="$TPM_TEST_DIR/tmux.conf"
+    local sourced="$TPM_TEST_DIR/plugins.conf"
+
+    echo "set -g @plugin 'user/only-once'" > "$sourced"
+    cat > "$config" <<EOF
+source-file $sourced
+source-file $sourced
+EOF
+
+    run parse_plugins "$config"
+    [ "$status" -eq 0 ]
+    [ "${#lines[@]}" -eq 1 ]
+    [ "$output" = "user/only-once" ]
+}


### PR DESCRIPTION
Fixes #35 - plugins declared in files sourced via `source-file` or `source` directives were silently ignored, causing empty plugin lists.

`parse_plugins` now recursively follows source directives, with guards for circular references, duplicate sourcing, relative paths, and tilde expansion.