### PR TITLE
fix: make format_commit_display test colour-agnostic

### DIFF
--- a/tests/update_test.bats
+++ b/tests/update_test.bats
@@ -507,7 +507,7 @@ EOF
 ${third_hash}|Third commit|10 minutes ago
 ${second_hash}|Second commit|15 minutes ago"
 
-    run format_commit_display "test-plugin" "$old_hash" "$new_hash" "$commits" "updated" "$plugin_path"
+    NO_COLOR=1 run format_commit_display "test-plugin" "$old_hash" "$new_hash" "$commits" "updated" "$plugin_path"
     [ "$status" -eq 0 ]
     [ -n "$output" ]
     # Should show "updated from X to Y"


### PR DESCRIPTION
The test was counting commit lines using a regex that expected plain text (^  [a-f0-9]{7}), but locally TERM=xterm-256color caused colour_meta to emit ANSI codes even without a TTY, breaking the match. Set NO_COLOR=1 for the assertion that counts commit lines to make it deterministic.